### PR TITLE
add parameter to receive watch bookmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- This changelog
+
+### Fixed
+- Instruct Kubernetes to send bookmark events for watches. This ensures restarted watches start from a recent
+  enough resource version. [#6]
+- Fixes the resource filter applied to PVC and VA watches. A bug introduced in 0.1.2 caused the HA Controller to filter
+  all resources (Pods, PVCs, VolumeAttachments) based on filters for Pods.
+
+[#6]: https://github.com/piraeusdatastore/piraeus-ha-controller/pull/6
+
+## [0.1.2] - 2021-01-12
+### Added
+- `--leader-election-resource-name` option added. Used to set the name of the lease resource [#1]
+
+[#1]: https://github.com/piraeusdatastore/piraeus-ha-controller/pull/1
+
+### Fixed
+- Kubernetes Watches are now re-tried instead of crashing the whole application in case of timeouts [#5]
+
+[#5]: https://github.com/piraeusdatastore/piraeus-ha-controller/pull/5
+
+## [0.1.1] - 2020-12-16
+### Fixed
+- Fixed a crash caused by watching PersistentVolumeClaims instead VolumeAttachments
+
+## [0.1.0] - 2020-12-15
+### Added
+- Initial implementation of HA Controller (watching Kubernetes and LINSTOR events, deleting Pods and VolumeAttachments)
+- Deployment example
+- README with motivating example
+
+[Unreleased]: https://github.com/piraeusdatastore/piraeus-ha-controller/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/piraeusdatastore/piraeus-ha-controller/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/piraeusdatastore/piraeus-ha-controller/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/piraeusdatastore/piraeus-ha-controller/releases/tag/v0.1.0


### PR DESCRIPTION
Watch bookmarks periodically sends updated resource versions for watches.
We already expect these in case we need to restart a failed watch. This commit
adds the required query option to the API call, fixing errors when restarting
the watch with a too old resource version.
    
Also fixes an issue that would restrict the updates we receive based on the
Pod selector even for non-pod resources.

Also adds a changelog

See this comment: https://github.com/piraeusdatastore/piraeus-ha-controller/issues/2#issuecomment-759909768 for why we need bookmarks