### PR TITLE
docker: include linstor-wait-until utility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.17 as builder
+# syntax=docker/dockerfile:1
+FROM --platform=$BUILDPLATFORM golang:1.17 as builder
 
 WORKDIR /src/
 COPY go.* /src/
@@ -11,9 +12,19 @@ COPY pkg /src/pkg
 ARG GOOS=linux
 ARG VERSION=v0.0.0-0.unknown
 
-RUN CGO_ENABLED=0 go build -ldflags="-X github.com/piraeusdatastore/piraeus-ha-controller/pkg/consts.Version=${VERSION} -extldflags=-static"  -v ./cmd/...
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-X github.com/piraeusdatastore/piraeus-ha-controller/pkg/consts.Version=${VERSION} -extldflags=-static"  -v ./cmd/...
+
+FROM --platform=$BUILDPLATFORM golang:1.17 as downloader
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG LINSTOR_WAIT_UNTIL_VERSION=v0.1.1
+RUN curl -fsSL https://github.com/LINBIT/linstor-wait-until/releases/download/$LINSTOR_WAIT_UNTIL_VERSION/linstor-wait-until-$LINSTOR_WAIT_UNTIL_VERSION-$TARGETOS-$TARGETARCH.tar.gz | tar xvzC /
 
 FROM gcr.io/distroless/static:latest
 COPY --from=builder /src/piraeus-ha-controller /piraeus-ha-controller
+COPY --from=downloader /linstor-wait-until /linstor-wait-until
 USER nonroot
 ENTRYPOINT ["/piraeus-ha-controller"]

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -19,6 +19,15 @@ spec:
         app.kubernetes.io/name: piraeus-ha-controller
     spec:
       serviceAccountName: ha-controller
+      initContainers:
+        - name: wait-for-linstor
+          image: quay.io/piraeusdatastore/piraeus-ha-controller:v0.2.0
+          command:
+            - /linstor-wait-until
+            - api-online
+          env:
+            - name: LS_CONTROLLERS
+              value: http://piraeus-op-cs.default.svc:3370
       containers:
         - name: controller
           image: quay.io/piraeusdatastore/piraeus-ha-controller:v0.2.0


### PR DESCRIPTION
The utility is useful when delaying container start until the LINSTOR apiis ready.