### PR TITLE
failover: force delete pods on unresponsive nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Force deletion of Pods if running Node appears not ready (i.e. it cannot confirm deletion of the Pod).
+
 ## [1.0.0-rc.2] - 2022-06-28
 
 ### Changed

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -55,7 +55,7 @@ func NewAgentCommand() *cobra.Command {
 
 				mux := &http.ServeMux{}
 				mux.HandleFunc("/healthz", func(writer http.ResponseWriter, request *http.Request) {
-					ag.Healtz(writer)
+					ag.Healthz(writer)
 				})
 
 				go http.Serve(listener, mux)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -271,7 +271,7 @@ func (a *agent) reconcile(ctx context.Context, recorder events.EventRecorder) er
 	return nil
 }
 
-func (a *agent) Healtz(writer http.ResponseWriter) {
+func (a *agent) Healthz(writer http.ResponseWriter) {
 	a.mu.Lock()
 	sinceLastReconcile := time.Now().Sub(a.lastReconcileStart)
 	a.mu.Unlock()

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -255,6 +255,8 @@ func (a *agent) reconcile(ctx context.Context, recorder events.EventRecorder) er
 			go func() {
 				defer wg.Done()
 
+				klog.V(3).Infof("reconcile '%T' for resource '%s'", r, req.Resource.Name)
+
 				ctx, cancel := context.WithTimeout(ctx, a.Timeout())
 				defer cancel()
 
@@ -262,6 +264,8 @@ func (a *agent) reconcile(ctx context.Context, recorder events.EventRecorder) er
 				if err != nil {
 					klog.V(1).Infof("reconciliation failed: %v", err)
 				}
+
+				klog.V(3).Infof("reconcile '%T' for resource '%s' ended", r, req.Resource.Name)
 			}()
 		}
 	}

--- a/pkg/agent/drbd.go
+++ b/pkg/agent/drbd.go
@@ -95,6 +95,31 @@ func (d *drbdResources) Get() []DrbdResourceState {
 	return result
 }
 
+type DrbdConnection struct {
+	PeerNodeId      int    `json:"peer-node-id"`
+	Name            string `json:"name"`
+	ConnectionState string `json:"connection-state"`
+	Congested       bool   `json:"congested"`
+	PeerRole        string `json:"peer-role"`
+	ApInFlight      int    `json:"ap-in-flight"`
+	RsInFlight      int    `json:"rs-in-flight"`
+	PeerDevices     []struct {
+		Volume                 int     `json:"volume"`
+		ReplicationState       string  `json:"replication-state"`
+		PeerDiskState          string  `json:"peer-disk-state"`
+		PeerClient             bool    `json:"peer-client"`
+		ResyncSuspended        string  `json:"resync-suspended"`
+		Received               int     `json:"received"`
+		Sent                   int     `json:"sent"`
+		OutOfSync              int     `json:"out-of-sync"`
+		Pending                int     `json:"pending"`
+		Unacked                int     `json:"unacked"`
+		HasSyncDetails         bool    `json:"has-sync-details"`
+		HasOnlineVerifyDetails bool    `json:"has-online-verify-details"`
+		PercentInSync          float64 `json:"percent-in-sync"`
+	} `json:"peer_devices"`
+}
+
 // DrbdResourceState is the parsed output of "drbdsetup status --json".
 type DrbdResourceState struct {
 	Name             string `json:"name"`
@@ -121,30 +146,7 @@ type DrbdResourceState struct {
 		UpperPending int    `json:"upper-pending"`
 		LowerPending int    `json:"lower-pending"`
 	} `json:"devices"`
-	Connections []struct {
-		PeerNodeId      int    `json:"peer-node-id"`
-		Name            string `json:"name"`
-		ConnectionState string `json:"connection-state"`
-		Congested       bool   `json:"congested"`
-		PeerRole        string `json:"peer-role"`
-		ApInFlight      int    `json:"ap-in-flight"`
-		RsInFlight      int    `json:"rs-in-flight"`
-		PeerDevices     []struct {
-			Volume                 int     `json:"volume"`
-			ReplicationState       string  `json:"replication-state"`
-			PeerDiskState          string  `json:"peer-disk-state"`
-			PeerClient             bool    `json:"peer-client"`
-			ResyncSuspended        string  `json:"resync-suspended"`
-			Received               int     `json:"received"`
-			Sent                   int     `json:"sent"`
-			OutOfSync              int     `json:"out-of-sync"`
-			Pending                int     `json:"pending"`
-			Unacked                int     `json:"unacked"`
-			HasSyncDetails         bool    `json:"has-sync-details"`
-			HasOnlineVerifyDetails bool    `json:"has-online-verify-details"`
-			PercentInSync          float64 `json:"percent-in-sync"`
-		} `json:"peer_devices"`
-	} `json:"connections"`
+	Connections []DrbdConnection `json:"connections"`
 }
 
 // MayPromote returns the best local approximation of the may promote flag from "drbdsetup events2".

--- a/pkg/agent/reconcile_force_io_error_pods.go
+++ b/pkg/agent/reconcile_force_io_error_pods.go
@@ -81,6 +81,9 @@ func (f *forceIoErrorReconciler) RunForResource(ctx context.Context, req *Reconc
 			return fmt.Errorf("pod '%s/%s' does not have an owner", pod.Namespace, pod.Name)
 		}
 
+		// NB: we only evict here, and never do a forceful deletion as in the failover case. In here we only evict
+		// Pods that are running on the local node, so kubelet better be able to terminate Pods.
+
 		err = eviction.Evict(ctx, f.client, pod.Namespace, pod.Name, metav1.DeleteOptions{
 			GracePeriodSeconds: &f.opt.DeletionGraceSec,
 			Preconditions:      metav1.NewUIDPreconditions(string(pod.UID)),


### PR DESCRIPTION
Eviction always waits for confirmation by the kubelet to complete. This is
not ideal if the whole node crashed, as then kubelet can't confirm deletion,
and we are stuck with Pods in Terminating state. This is especially bad
in case of StatefulSets, as those won't ever recreate the Pod, as the old
one is still visible, even if it is factually gone.

The solution is to check the node state in the fail over case, and
if kubernetes reports that the node is not ready, we force delete the
pod from the API without waiting for any kind of acknowledgement by
the kubelet.

Also fixes a small typo