### PR TITLE
Ignore other volume types by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a bug that meant the manual Pod exemption from fail over via annotations would be ignored.
+
 ## [1.0.1] - 2022-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Exempt Pods that are attached to other types of storage by default, unless the volumes are known to be safe (such as
+  ConfigMap, DownwardAPI, Secret, and other readonly volumes).
+
 ### Fixed
 - Fixed a bug that meant the manual Pod exemption from fail over via annotations would be ignored.
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -20,6 +20,7 @@ func NewAgentCommand() *cobra.Command {
 	var drbdStatusInterval, reconcileInterval, resyncInterval, operationsTimeout, failOverTimeout time.Duration
 	var deletionGraceSeconds int64
 	var nodeName, healthzBindAddress string
+	var failOverUnsafePods bool
 
 	cmd := &cobra.Command{
 		Use:     "node-agent",
@@ -42,6 +43,7 @@ func NewAgentCommand() *cobra.Command {
 				DrbdStatusInterval: drbdStatusInterval,
 				FailOverTimeout:    failOverTimeout,
 				NodeName:           nodeName,
+				FailOverUnsafePods: failOverUnsafePods,
 			})
 			if err != nil {
 				return err
@@ -74,6 +76,7 @@ func NewAgentCommand() *cobra.Command {
 	cmd.Flags().Int64Var(&deletionGraceSeconds, "grace-period-seconds", 10, "default grace period for deleting k8s objects, in seconds")
 	cmd.Flags().StringVar(&nodeName, "node-name", os.Getenv("NODE_NAME"), "the name of node this is running on. defaults to the NODE_NAME environment variable")
 	cmd.Flags().StringVar(&healthzBindAddress, "health-bind-address", ":8000", "the address to bind to for the /healthz endpoint")
+	cmd.Flags().BoolVar(&failOverUnsafePods, "fail-over-unsafe-pods", false, "fail over Pods that use storage with unknown fail over properties")
 	return cmd
 }
 

--- a/pkg/agent/reconcile_failover.go
+++ b/pkg/agent/reconcile_failover.go
@@ -6,15 +6,18 @@ import (
 	"sync"
 	"time"
 
+	csilinstor "github.com/piraeusdatastore/linstor-csi/pkg/linstor"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 
 	"github.com/piraeusdatastore/piraeus-ha-controller/pkg/eviction"
+	"github.com/piraeusdatastore/piraeus-ha-controller/pkg/indexers"
 	"github.com/piraeusdatastore/piraeus-ha-controller/pkg/metadata"
 )
 
@@ -24,6 +27,7 @@ type failoverReconciler struct {
 	opt          *Options
 	client       kubernetes.Interface
 	drbdFailedAt map[string]time.Time
+	pvIndexer    cache.Indexer
 	mu           sync.Mutex
 }
 
@@ -39,11 +43,12 @@ type failoverReconciler struct {
 // * Adding a taint on the node, causing new Pods to avoid the node.
 // * Evicting all pods using that volume from the failed node, creating new pods to replace them.
 // * Delete the volume attachment, informing Kubernetes that attaching the volume to a new node is fine.
-func NewFailoverReconciler(opt *Options, client kubernetes.Interface) Reconciler {
+func NewFailoverReconciler(opt *Options, client kubernetes.Interface, pvIndexer cache.Indexer) Reconciler {
 	return &failoverReconciler{
 		opt:          opt,
 		client:       client,
 		drbdFailedAt: make(map[string]time.Time),
+		pvIndexer:    pvIndexer,
 	}
 }
 
@@ -178,6 +183,11 @@ func (f *failoverReconciler) evictPods(ctx context.Context, res *DrbdResourceSta
 				return
 			}
 
+			if !f.opt.FailOverUnsafePods && !f.OnlySafeVolumes(pod) {
+				klog.V(2).Infof("Pod '%s/%s' is exempt from eviction because of unsafe volumes", pod.Namespace, pod.Name)
+				return
+			}
+
 			if nodeReady(node) {
 				klog.V(2).Infof("Node %s running Pod '%s/%s' appears ready, using graceful eviction", node.Name, pod.Namespace, pod.Name)
 
@@ -243,6 +253,51 @@ func (f *failoverReconciler) evictPods(ctx context.Context, res *DrbdResourceSta
 	}
 
 	return nil
+}
+
+func (f *failoverReconciler) IsSafeVolume(vol *corev1.Volume, namespace string) bool {
+	switch {
+	// All of these are always safe to fail over
+	case vol.ConfigMap != nil:
+	case vol.CSI != nil:
+	case vol.DownwardAPI != nil:
+	case vol.EmptyDir != nil:
+	case vol.Ephemeral != nil:
+	case vol.GitRepo != nil:
+	case vol.Projected != nil:
+	case vol.Secret != nil:
+	// Sometimes safe to fail over, depending on driver and read-only mode
+	case vol.PersistentVolumeClaim != nil:
+		if vol.PersistentVolumeClaim.ReadOnly {
+			return true
+		}
+
+		pvs, err := indexers.List[corev1.PersistentVolume](f.pvIndexer.ByIndex("pvc", fmt.Sprintf("%s/%s", namespace, vol.PersistentVolumeClaim.ClaimName)))
+		if err != nil {
+			return false
+		}
+
+		if len(pvs) != 1 {
+			return false
+		}
+
+		pv := pvs[0]
+		return pv.Spec.CSI != nil && (pv.Spec.CSI.ReadOnly || pv.Spec.CSI.Driver == csilinstor.DriverName)
+	// Unknown, assume it's not safe to fail over
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (f *failoverReconciler) OnlySafeVolumes(pod *corev1.Pod) bool {
+	for i := range pod.Spec.Volumes {
+		if !f.IsSafeVolume(&pod.Spec.Volumes[i], pod.Namespace) {
+			return false
+		}
+	}
+	return true
 }
 
 func ignoreNotFound(err error) error {

--- a/pkg/agent/reconcile_failover.go
+++ b/pkg/agent/reconcile_failover.go
@@ -175,6 +175,7 @@ func (f *failoverReconciler) evictPods(ctx context.Context, res *DrbdResourceSta
 
 			if _, exists := pod.ObjectMeta.Annotations[metadata.AnnotationIgnoreFailOver]; exists {
 				klog.V(2).Infof("Pod '%s/%s' is exempt from eviction per annotation", pod.Namespace, pod.Name)
+				return
 			}
 
 			if nodeReady(node) {


### PR DESCRIPTION
See #18 for motivation.

This currently only works for the most common other volume types. There are a bunch of other volumes which might work, depending on their read-only flag.