### PR TITLE
drbd: only parse needed items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- No longer attempt to parse numbers from drbdsetup status that are not relevant. This prevents issue when said numbers
+  are outside the expected range.
+
 ## [1.1.0] - 2022-08-08
 
 ### Added

--- a/pkg/agent/drbd.go
+++ b/pkg/agent/drbd.go
@@ -96,57 +96,23 @@ func (d *drbdResources) Get() []DrbdResourceState {
 }
 
 type DrbdConnection struct {
-	PeerNodeId      int    `json:"peer-node-id"`
 	Name            string `json:"name"`
-	ConnectionState string `json:"connection-state"`
-	Congested       bool   `json:"congested"`
 	PeerRole        string `json:"peer-role"`
-	ApInFlight      int    `json:"ap-in-flight"`
-	RsInFlight      int    `json:"rs-in-flight"`
-	PeerDevices     []struct {
-		Volume                 int     `json:"volume"`
-		ReplicationState       string  `json:"replication-state"`
-		PeerDiskState          string  `json:"peer-disk-state"`
-		PeerClient             bool    `json:"peer-client"`
-		ResyncSuspended        string  `json:"resync-suspended"`
-		Received               int     `json:"received"`
-		Sent                   int     `json:"sent"`
-		OutOfSync              int     `json:"out-of-sync"`
-		Pending                int     `json:"pending"`
-		Unacked                int     `json:"unacked"`
-		HasSyncDetails         bool    `json:"has-sync-details"`
-		HasOnlineVerifyDetails bool    `json:"has-online-verify-details"`
-		PercentInSync          float64 `json:"percent-in-sync"`
-	} `json:"peer_devices"`
+	ConnectionState string `json:"connection-state"`
+}
+
+type DrbdDevice struct {
+	Quorum bool `json:"quorum"`
 }
 
 // DrbdResourceState is the parsed output of "drbdsetup status --json".
 type DrbdResourceState struct {
-	Name             string `json:"name"`
-	NodeId           int    `json:"node-id"`
-	Role             string `json:"role"`
-	Suspended        bool   `json:"suspended"`
-	SuspendedUser    bool   `json:"suspended-user"`
-	SuspendedNoData  bool   `json:"suspended-no-data"`
-	SuspendedFencing bool   `json:"suspended-fencing"`
-	SuspendedQuorum  bool   `json:"suspended-quorum"`
-	ForceIoFailures  bool   `json:"force-io-failures"`
-	WriteOrdering    string `json:"write-ordering"`
-	Devices          []struct {
-		Volume       int    `json:"volume"`
-		Minor        int    `json:"minor"`
-		DiskState    string `json:"disk-state"`
-		Client       bool   `json:"client"`
-		Quorum       bool   `json:"quorum"`
-		Size         int    `json:"size"`
-		Read         int    `json:"read"`
-		Written      int    `json:"written"`
-		AlWrites     int    `json:"al-writes"`
-		BmWrites     int    `json:"bm-writes"`
-		UpperPending int    `json:"upper-pending"`
-		LowerPending int    `json:"lower-pending"`
-	} `json:"devices"`
-	Connections []DrbdConnection `json:"connections"`
+	Name            string           `json:"name"`
+	Role            string           `json:"role"`
+	Suspended       bool             `json:"suspended"`
+	ForceIoFailures bool             `json:"force-io-failures"`
+	Devices         []DrbdDevice     `json:"devices"`
+	Connections     []DrbdConnection `json:"connections"`
 }
 
 // MayPromote returns the best local approximation of the may promote flag from "drbdsetup events2".

--- a/pkg/agent/drbd_test.go
+++ b/pkg/agent/drbd_test.go
@@ -1,0 +1,26 @@
+package agent_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/piraeusdatastore/piraeus-ha-controller/pkg/agent"
+)
+
+func TestUnmarshalDrbdResourceState(t *testing.T) {
+	source := `[{"peer-node-id":0,"name":"4b","connection-state":"Connecting","congested":false,"peer-role":"Unknown","ap-in-flight":18446744073709551608,"rs-in-flight":0,"peer_devices":[{"volume":0,"replication-state":"Off","peer-disk-state":"DUnknown","peer-client":false,"resync-suspended":"no","received":0,"sent":0,"out-of-sync":0,"pending":0,"unacked":0,"has-sync-details":false,"has-online-verify-details":false,"percent-in-sync":100.00}]}]`
+
+	var result []agent.DrbdResourceState
+	err := json.Unmarshal([]byte(source), &result)
+	assert.NoError(t, err)
+	assert.Equal(t, []agent.DrbdResourceState{
+		{
+			Name:            "4b",
+			Role:            "",
+			ForceIoFailures: false,
+			Suspended:       false,
+		},
+	}, result)
+}


### PR DESCRIPTION
The ad-hoc parser for the output of drbdsetup status would sometimes fail. This was caused by large values in fields that only expected "int".

Instead of manually checking the possible range, we can just remove those fields, as they do not hold any relevant information for the inner workings of the HA Controller.

Fixes #21 