### PR TITLE
failover: ignore non-running Pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ignore non-running Pods during fail-over events.
+
 ## [1.1.2] - 2023-02-20
 
 ### Changed


### PR DESCRIPTION
The failover controller should only try to evict running Pods. Otherwise, in a situation where there is only one Node that can run a Pod, the Pod might get repeatedly created and removed by the other nodes HA Controller while the Satellite is reconnected.