### PR TITLE
Match Connection Names based on Satellite Pods

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          only-new-issues: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,13 +8,13 @@ on:
 jobs:
   test:
     name: Run tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Go environment
         uses: actions/setup-go@v5
         with:
-          go-version: '1.19'
+          go-version: '1.21'
       - name: run tests
         run: go test ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Option to assume connection names refer to a Pod instead of a Node.
+
 ## [1.1.4] - 2023-05-22
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM --platform=$BUILDPLATFORM golang:1.19 as builder
+FROM --platform=$BUILDPLATFORM golang:1.21 as builder
 
 WORKDIR /src/
 COPY go.* /src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-X github.com/piraeusdatastore/piraeus-ha-controller/pkg/metadata.Version=${VERSION} -extldflags=-static"  -v ./cmd/agent
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 RUN <<EOF
   set -e
@@ -24,7 +24,7 @@ RUN <<EOF
   apt-get install -y wget ca-certificates gnupg
   { echo 'APT::Install-Recommends "false";' ; echo 'APT::Install-Suggests "false";' ; } > /etc/apt/apt.conf.d/99_piraeus
   wget -O- https://packages.linbit.com/package-signing-pubkey.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/linbit-keyring.gpg
-  echo "deb http://packages.linbit.com/public" bullseye "misc" > /etc/apt/sources.list.d/linbit.list
+  echo "deb http://packages.linbit.com/public" bookworm "misc" > /etc/apt/sources.list.d/linbit.list
   apt-get update
   apt-get install -y drbd-utils
   apt-get clean -y

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	k8scli "k8s.io/component-base/cli"
+	"k8s.io/klog/v2"
 
 	"github.com/piraeusdatastore/piraeus-ha-controller/pkg/agent"
 	"github.com/piraeusdatastore/piraeus-ha-controller/pkg/metadata"
@@ -60,7 +61,11 @@ func NewAgentCommand() *cobra.Command {
 					ag.Healthz(writer)
 				})
 
-				go http.Serve(listener, mux)
+				go func() {
+					err := http.Serve(listener, mux)
+					klog.Errorf("error serving /healthz endpoint: %s", err)
+					cancel()
+				}()
 			}
 
 			return ag.Run(ctx)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -117,6 +117,9 @@ func NewAgent(opt *Options) (*agent, error) {
 			return []string{fmt.Sprintf("%s/%s", obj.Spec.ClaimRef.Namespace, obj.Spec.ClaimRef.Name)}, nil
 		}),
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	klog.V(2).Info("setting up Pod informer")
 
@@ -297,7 +300,7 @@ func (a *agent) reconcile(ctx context.Context, recorder events.EventRecorder) er
 
 func (a *agent) Healthz(writer http.ResponseWriter) {
 	a.mu.Lock()
-	sinceLastReconcile := time.Now().Sub(a.lastReconcileStart)
+	sinceLastReconcile := time.Since(a.lastReconcileStart)
 	a.mu.Unlock()
 
 	if sinceLastReconcile > a.Timeout()+a.ReconcileInterval {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -183,7 +183,10 @@ func (a *agent) Run(ctx context.Context) error {
 
 	recorder := a.broadcaster.NewRecorder(scheme.Scheme, metadata.EventsReporter)
 
-	a.broadcaster.StartRecordingToSink(ctx.Done())
+	err := a.broadcaster.StartRecordingToSinkWithContext(ctx)
+	if err != nil {
+		return err
+	}
 	defer a.broadcaster.Shutdown()
 
 	klog.V(2).Info("setting up periodic reconciliation ticker")


### PR DESCRIPTION
With the switch to using daemonset-controlled satellite Pods, LINSTOR may use the Pod name instead of the hostname for DRBD connections. To support this in the HA controller, watch for satellite pods, and if a connection name matches the name of the Pod, use the Pods `.spec.nodeName` instead of using the connections name directly.

See also https://github.com/piraeusdatastore/piraeus-operator/pull/586