### PR TITLE
failover: fix safe volume detection using the wrong indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed detection of Persistent Volume Claims when deciding to fail over Pods.
+
 ## [1.2.0] - 2024-01-05
 
 ### Added

--- a/pkg/agent/reconcile_failover.go
+++ b/pkg/agent/reconcile_failover.go
@@ -276,7 +276,7 @@ func (f *failoverReconciler) IsSafeVolume(vol *corev1.Volume, namespace string) 
 			return true
 		}
 
-		pvs, err := indexers.List[corev1.PersistentVolume](f.pvIndexer.ByIndex("pvc", fmt.Sprintf("%s/%s", namespace, vol.PersistentVolumeClaim.ClaimName)))
+		pvs, err := indexers.List[corev1.PersistentVolume](f.pvIndexer.ByIndex(PersistentVolumeByPersistentVolumeClaimIndex, fmt.Sprintf("%s/%s", namespace, vol.PersistentVolumeClaim.ClaimName)))
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
We try to detect the volumes of a Pod to determine if it safe to fail over. However, we used the wrong index to get the persistent volume from the configured persistent volume claim. This meant that Pods using PVCs where considered unsafe, even if they where using DRBD resources.

To fix the issue, use the correct indexer name defined in a const.