### PR TITLE
agent: assume PVs without claimRef.kind refer to PVCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Consider PVs with ClaimRef without apiVersion and kind set to also refer to PVCs.
+
 ## [1.2.2] - 2024-10-16
 
 ### Changed


### PR DESCRIPTION
There might be situations where a cluster has PVs that have a claimRef set without explicit apiVersion and kind set. This seems to primarily happen when Volume Populators are involved.

To fix this, assume PVs that have no explicit apiVersion and kind set still refer to PVCs.

Fixes #77 