### PR TITLE
Make node taints optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The Piraeus High Availability Controller itself can be configured using the foll
 --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 --resync-interval duration         how often the internal object cache should be resynchronized (default 5m0s)
 --v int32                          set log level (default 0)
+--disable-node-taints boolean      when set to true; node taints will not be applied (default false)
 ```
 
 You can directly set them through the helm chart using the matching `options` value.

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -22,7 +22,7 @@ func NewAgentCommand() *cobra.Command {
 	var drbdStatusInterval, reconcileInterval, resyncInterval, operationsTimeout, failOverTimeout time.Duration
 	var deletionGraceSeconds int64
 	var nodeName, healthzBindAddress, satellitePodLabel string
-	var failOverUnsafePods bool
+	var failOverUnsafePods, disableNodeTaints bool
 
 	cmd := &cobra.Command{
 		Use:     "node-agent",
@@ -52,6 +52,7 @@ func NewAgentCommand() *cobra.Command {
 				NodeName:             nodeName,
 				FailOverUnsafePods:   failOverUnsafePods,
 				SatellitePodSelector: selector,
+				DisableNodeTaints:    disableNodeTaints,
 			})
 			if err != nil {
 				return err
@@ -90,6 +91,7 @@ func NewAgentCommand() *cobra.Command {
 	cmd.Flags().StringVar(&healthzBindAddress, "health-bind-address", ":8000", "the address to bind to for the /healthz endpoint")
 	cmd.Flags().StringVar(&satellitePodLabel, "satellite-pod-label", "app.kubernetes.io/component=linstor-satellite", "the connection name reported by DRBD is one of the Pods with this label")
 	cmd.Flags().BoolVar(&failOverUnsafePods, "fail-over-unsafe-pods", false, "fail over Pods that use storage with unknown fail over properties")
+	cmd.Flags().BoolVar(&disableNodeTaints, "disable-node-taints", false, "prevent nodes from being tainted")
 	return cmd
 }
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -568,7 +568,7 @@ func hasPersistentVolumeClaimRef(pv *corev1.PersistentVolume) bool {
 
 // TaintNode adds the specific taint to the node.
 //
-// Returns false, nil if the taint was already present.
+// Returns false, nil if the taint was already present or applying node taints had been disabled.
 func TaintNode(ctx context.Context, client kubernetes.Interface, node *corev1.Node, taint corev1.Taint, disableNodeTaints bool) (bool, error) {
 	if disableNodeTaints || node == nil {
 		return false, nil

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -54,6 +54,8 @@ type Options struct {
 	// SatellitePodSelector selects the Pods that should be considered LINSTOR Satellites.
 	// If the DRBD connection name matches on of these Pods, the Kubernetes Node name is taken from these Pods.
 	SatellitePodSelector labels.Selector
+	// DisableNodeTaints prevents the nodes in a cluster from being tainted.
+	DisableNodeTaints bool
 }
 
 // Timeout returns the operations timeout.
@@ -567,8 +569,8 @@ func hasPersistentVolumeClaimRef(pv *corev1.PersistentVolume) bool {
 // TaintNode adds the specific taint to the node.
 //
 // Returns false, nil if the taint was already present.
-func TaintNode(ctx context.Context, client kubernetes.Interface, node *corev1.Node, taint corev1.Taint) (bool, error) {
-	if node == nil {
+func TaintNode(ctx context.Context, client kubernetes.Interface, node *corev1.Node, taint corev1.Taint, disableNodeTaints bool) (bool, error) {
+	if disableNodeTaints || node == nil {
 		return false, nil
 	}
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -445,6 +445,10 @@ func (a *agent) ManageOwnTaints(ctx context.Context, resourceState []DrbdResourc
 	if len(eventUpdates) != 0 {
 		klog.V(1).Info("updating node taints")
 
+		if a.Options.DisableNodeTaints {
+			updatedTaints = []corev1.Taint{}
+		}
+
 		// server-side apply updates would be nicer, but don't work in all situations.
 		// Adding taints works as expected, but removing taints controlled by this agent would also
 		// remove _all_ other existing taints. So we use a plain update instead.

--- a/pkg/agent/reconcile_failover.go
+++ b/pkg/agent/reconcile_failover.go
@@ -148,7 +148,7 @@ func (f *failoverReconciler) evictPods(ctx context.Context, res *DrbdResourceSta
 		Key:       metadata.NodeLostQuorumTaint,
 		Effect:    corev1.TaintEffectNoSchedule,
 		TimeAdded: &taintTime,
-	})
+	}, f.opt.DisableNodeTaints)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/reconcile_force_io_error_pods.go
+++ b/pkg/agent/reconcile_force_io_error_pods.go
@@ -65,7 +65,7 @@ func (f *forceIoErrorReconciler) RunForResource(ctx context.Context, req *Reconc
 		Key:       metadata.NodeForceIoErrorTaint,
 		Effect:    corev1.TaintEffectNoSchedule,
 		TimeAdded: &taintTime,
-	})
+	}, f.opt.DisableNodeTaints)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding a flag to allow users to configure the HA controller to not apply node taints.