### PR TITLE
ci: pass build metadata to cosign via env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,9 @@ jobs:
         # Take the digest we just pushed to the registry and sign the image using "keyless" signing:
         #   https://docs.sigstore.dev/cosign/signing/overview/
         # With this, users can verify that the image was actually created by this github workflow.
+        env:
+          BUILD_METADATA: ${{ steps.build.outputs.metadata }}
         run: |
-          jq '."containerimage.digest" as $DIGEST | ."image.name" | split(":")[0] | "\(.)@\($DIGEST)"' -r <<<'${{ steps.build.outputs.metadata }}' \
+          printf '%s' "$BUILD_METADATA" \
+            | jq '."containerimage.digest" as $DIGEST | ."image.name" | split(":")[0] | "\(.)@\($DIGEST)"' -r \
             | xargs --no-run-if-empty cosign sign --yes


### PR DESCRIPTION
The sign step inlined the build step's metadata output into the shell with a single-quoted here-string. GitHub expands ${{ }} before the shell parses the script, and with provenance attestation (mode=max) that metadata JSON embeds commit messages. An apostrophe in a commit message closed the single quote, after which the shell failed on the next "(" with a syntax error.

Pass the metadata through a BUILD_METADATA environment variable and read it with printf, so its contents are never parsed by the shell.