### PR TITLE
Delay own-node quorum taint by fail-over timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Only taint the local node after a resource stayed without quorum for the fail-over timeout. Freshly
+  created resources briefly report no quorum before their first connection, which caused the taint to be
+  added and immediately removed again.
+
 ## [1.3.3] - 2026-07-08
 
 ### Fixed

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -87,6 +87,10 @@ type agent struct {
 
 	mu                 sync.Mutex
 	lastReconcileStart time.Time
+
+	// noQuorumSince tracks when a resource was first seen without quorum.
+	// Only accessed from ManageOwnTaints, which never runs concurrently.
+	noQuorumSince map[string]time.Time
 }
 
 const (
@@ -190,6 +194,7 @@ func NewAgent(opt *Options) (*agent, error) {
 		client:          client,
 		broadcaster:     broadcaster,
 		Options:         opt,
+		noQuorumSince:   make(map[string]time.Time),
 		reconcilers: []Reconciler{
 			NewFailoverReconciler(opt, client, pvInformer.GetIndexer()),
 			NewSuspendedPodReconciler(opt),
@@ -364,6 +369,9 @@ func (a *agent) Healthz(writer http.ResponseWriter) {
 // ManageOwnTaints ensures that the taints on the local node are up to date:
 // * If all resources are in a good state, remove all taints.
 // * Add taints for DRBD resources that are forcing IO errors.
+// A resource only counts as having lost quorum after it stayed in that state
+// for the fail-over timeout, so fresh resources that have yet to connect do
+// not cause the taint to be added and immediately removed again.
 func (a *agent) ManageOwnTaints(ctx context.Context, resources map[string]*DrbdResource, refTime time.Time, recorder events.EventRecorder) error {
 	if a.Options.DisableNodeTaints {
 		klog.V(4).InfoS("not updating node taints", "disableNodeTaints", a.Options.DisableNodeTaints)
@@ -377,13 +385,28 @@ func (a *agent) ManageOwnTaints(ctx context.Context, resources map[string]*DrbdR
 			anyForceIOError = true
 		}
 
-		if allQuorum {
-			for j := range resource.State.Devices {
-				if resource.Config.Options.Quorum == QuorumMajority && !resource.State.Devices[j].Quorum {
-					allQuorum = false
-					break
-				}
-			}
+		if resource.Config.Options.Quorum != QuorumMajority || resource.State.HasQuorum() {
+			delete(a.noQuorumSince, resource.Name)
+			continue
+		}
+
+		noQuorumSince, ok := a.noQuorumSince[resource.Name]
+		if !ok {
+			a.noQuorumSince[resource.Name] = refTime
+			noQuorumSince = refTime
+		}
+
+		if noQuorumSince.Add(a.FailOverTimeout).After(refTime) {
+			klog.V(3).Infof("resource '%s' without quorum has not reached fail-over timeout, ignoring", resource.Name)
+			continue
+		}
+
+		allQuorum = false
+	}
+
+	for name := range a.noQuorumSince {
+		if _, ok := resources[name]; !ok {
+			delete(a.noQuorumSince, name)
 		}
 	}
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1,0 +1,92 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/events"
+
+	"github.com/piraeusdatastore/piraeus-ha-controller/pkg/metadata"
+)
+
+func drbdResourceWithQuorum(name string, quorum bool) *DrbdResource {
+	res := &DrbdResource{
+		Name:   name,
+		Config: DrbdConfiguration{Resource: name},
+		State: DrbdResourceState{
+			Name:    name,
+			Devices: []DrbdDevice{{Quorum: quorum}},
+		},
+	}
+	res.Config.Options.Quorum = QuorumMajority
+	return res
+}
+
+func TestManageOwnTaints(t *testing.T) {
+	const nodeName = "node-a"
+	const failOverTimeout = 5 * time.Second
+
+	ctx := context.Background()
+	client := fake.NewClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}})
+	nodeInformer := informers.NewSharedInformerFactory(client, 0).Core().V1().Nodes().Informer()
+
+	a := &agent{
+		Options: &Options{
+			NodeName:        nodeName,
+			FailOverTimeout: failOverTimeout,
+		},
+		client:        client,
+		nodeInformer:  nodeInformer,
+		noQuorumSince: make(map[string]time.Time),
+	}
+
+	// The informer is never started, so mirror the fake API state into its store by hand.
+	syncedNode := func(t *testing.T) *corev1.Node {
+		t.Helper()
+		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.NoError(t, nodeInformer.GetStore().Add(node))
+		return node
+	}
+
+	recorder := events.NewFakeRecorder(20)
+	start := time.Now()
+
+	// A resource that just appeared without quorum does not taint the node.
+	syncedNode(t)
+	err := a.ManageOwnTaints(ctx, map[string]*DrbdResource{"res": drbdResourceWithQuorum("res", false)}, start, recorder)
+	assert.NoError(t, err)
+	assert.Empty(t, syncedNode(t).Spec.Taints)
+
+	// The same resource still without quorum after the fail-over timeout taints the node.
+	err = a.ManageOwnTaints(ctx, map[string]*DrbdResource{"res": drbdResourceWithQuorum("res", false)}, start.Add(failOverTimeout), recorder)
+	assert.NoError(t, err)
+	taints := syncedNode(t).Spec.Taints
+	if assert.Len(t, taints, 1) {
+		assert.Equal(t, metadata.NodeLostQuorumTaint, taints[0].Key)
+	}
+
+	// Once the resource regains quorum, the taint is removed.
+	err = a.ManageOwnTaints(ctx, map[string]*DrbdResource{"res": drbdResourceWithQuorum("res", true)}, start.Add(failOverTimeout+time.Second), recorder)
+	assert.NoError(t, err)
+	assert.Empty(t, syncedNode(t).Spec.Taints)
+
+	// A new no-quorum episode starts the fail-over timeout from scratch.
+	err = a.ManageOwnTaints(ctx, map[string]*DrbdResource{"res": drbdResourceWithQuorum("res", false)}, start.Add(failOverTimeout+2*time.Second), recorder)
+	assert.NoError(t, err)
+	assert.Empty(t, syncedNode(t).Spec.Taints)
+
+	// A resource without the majority quorum option never taints the node.
+	res := drbdResourceWithQuorum("plain", false)
+	res.Config.Options.Quorum = ""
+	err = a.ManageOwnTaints(ctx, map[string]*DrbdResource{"plain": res}, start.Add(time.Hour), recorder)
+	assert.NoError(t, err)
+	assert.Empty(t, syncedNode(t).Spec.Taints)
+	assert.Empty(t, a.noQuorumSince, "vanished and quorate resources are dropped from tracking")
+}


### PR DESCRIPTION
Freshly created DRBD resources briefly report no quorum before their first connection is established. ManageOwnTaints immediately tainted the local node in that state, only to remove the taint again on the next run, causing unnecessary churn.

Track when a resource was first seen without quorum and only count it towards the taint once it stayed in that state for the fail-over timeout, mirroring the grace period the fail-over reconciler already applies before tainting remote nodes.